### PR TITLE
Specify traits to TraitsView

### DIFF
--- a/traits_enaml/widgets/traits_view.py
+++ b/traits_enaml/widgets/traits_view.py
@@ -8,7 +8,7 @@
 from traits.api import HasTraits
 from traitsui.api import View
 
-from atom.api import Typed, List, set_default
+from atom.api import Typed, set_default
 
 from enaml.core.declarative import d_
 from enaml.widgets.raw_widget import RawWidget


### PR DESCRIPTION
Allows the user to choose specific traits to edit from the model. Not setting this attribute will show all traits on the model.
