### PR TITLE
Fix exception when `_window` is not initialized.

### DIFF
--- a/traits_enaml/widgets/enable_canvas.py
+++ b/traits_enaml/widgets/enable_canvas.py
@@ -36,4 +36,5 @@ class EnableCanvas(RawWidget):
 
     @observe('component')
     def component_changed(self, new):
-        self._window.component = new['value']
+        if self._window is not None:
+            self._window.component = new['value']


### PR DESCRIPTION
This fixes issue #16 .

Accessing `self.component` on line 27 is enough to trigger the atom
notification, at which point `self._window` might still be uninitialized.

This minimal examples reproduces the error:

```
from enable.api import Component as EnableComponent
from enaml.widgets.main_window import MainWindow
from virtualcore.ui.enable_canvas import EnableCanvas

enamldef Main(MainWindow):
    EnableCanvas:
        component <<  EnableComponent()
```

Running this code raises an error:

```
Traceback (most recent call last):
  File "/Users/pberkes/e/Shell-VirtualCore/canopy_vc/bin/enaml-run", line 9, in <module>
    load_entry_point('enaml==0.8.8', 'console_scripts', 'enaml-run')()
  File "/Users/pberkes/egit/enaml/enaml/runner.py", line 64, in main
    window.show()
  File "/Users/pberkes/egit/enaml/enaml/widgets/window.py", line 331, in show
    self.activate_proxy()
  File "/Users/pberkes/egit/enaml/enaml/widgets/toolkit_object.py", line 206, in activate_proxy
    child.activate_proxy()
  File "/Users/pberkes/egit/enaml/enaml/widgets/toolkit_object.py", line 203, in activate_proxy
    self.activate_top_down()
  File "/Users/pberkes/egit/enaml/enaml/widgets/toolkit_object.py", line 219, in activate_top_down
    self.proxy.activate_top_down()
  File "/Users/pberkes/egit/enaml/enaml/qt/qt_toolkit_object.py", line 75, in activate_top_down
    self.create_widget()
  File "/Users/pberkes/egit/enaml/enaml/qt/qt_raw_widget.py", line 21, in create_widget
    self.widget = self.declaration.create_widget(self.parent_widget())
  File "/Users/pberkes/egit/traits-enaml/traits_enaml/widgets/enable_canvas.py", line 27, in create_widget
    if self.component is not None:
  File "/Users/pberkes/egit/traits-enaml/traits_enaml/widgets/enable_canvas.py", line 40, in component_changed
    self._window.component = new['value']
AttributeError: 'NoneType' object has no attribute 'component'
```
