### PR TITLE
Uncomment code in gui test assistant

### DIFF
--- a/traits_enaml/testing/gui_test_assistant.py
+++ b/traits_enaml/testing/gui_test_assistant.py
@@ -2,6 +2,7 @@
 import contextlib
 import threading
 
+from enaml.application import deferred_call
 from enaml.qt.qt_application import QtApplication
 from enaml.qt.QtGui import QApplication
 from traits.testing.unittest_tools import _TraitsChangeCollector as TraitsChangeCollector
@@ -25,7 +26,6 @@ class GuiTestAssistant(TestAssistant):
 
     def tearDown(self):
         with self.event_loop_with_timeout(repeat=5):
-            print 'Deferred call'
             deferred_call(self.qt_app.closeAllWindows)
         del self.event_loop_helper
         self.enaml_app.destroy()


### PR DESCRIPTION
I have un-commented the code at the tearDown method of the GuiTestAssistant. It does not cause segfaults on travis-ci and Windows 64 & python 32bit (using enaml 0.8.8 and atom 0.3.4).

@dpinte can you check how it behaves on mac os?
