### PR TITLE
Add Enaml regression tests.

### DIFF
--- a/traits_enaml/enaml_tests/__init__.py
+++ b/traits_enaml/enaml_tests/__init__.py
@@ -1,0 +1,5 @@
+""" Regression test suite for Enaml.
+
+Only the Qt backend is tested.
+
+"""

--- a/traits_enaml/enaml_tests/test_toolkit_object.py
+++ b/traits_enaml/enaml_tests/test_toolkit_object.py
@@ -1,0 +1,23 @@
+import unittest
+
+from traits_enaml.testing.enaml_test_assistant import EnamlTestAssistant
+
+
+class TestToolkitObject(EnamlTestAssistant, unittest.TestCase):
+    """ Test the ToolkitObject interface. """
+
+    def test_destroy(self):
+        # The 'destroy' method should dispose the Qt control.
+
+        enaml_source = """
+from enaml.widgets.api import Label, MainWindow
+
+enamldef MainView(MainWindow): win:
+    Label:
+        text = 'test'
+"""
+
+        view, toolkit_view = self.parse_and_create(enaml_source)
+        label_control = self.find_toolkit_widget(toolkit_view, 'QtLabel')
+        with self.delete_widget(label_control):
+            view.destroy()


### PR DESCRIPTION
Enaml does not define tests, but on the other hand we need to make sure that the core content remains stable for our applications. This PR defines a new sub-package, `enaml_tests`, where we can store regression tests against `enaml` itself.

The first test defined here tests that the `destroy` method in QtToolkitObject deletes the Qt widget. This currently fails, and I filed a PR in Enaml to fix it.

Please only merge when Enaml is fixed.
