### PR TITLE
Fix import order in person.py example

### DIFF
--- a/examples/traits_view/person.py
+++ b/examples/traits_view/person.py
@@ -5,12 +5,12 @@
 # This file is open source software distributed according to the terms in
 # LICENSE.txt
 #
+import enaml
+from enaml.qt.qt_application import QtApplication
 
 from traits.api import HasTraits, Str, Range
 from traitsui.api import View
 
-import enaml
-from enaml.qt.qt_application import QtApplication
 
 
 class Person(HasTraits):


### PR DESCRIPTION
This PR fixes the import order so that enaml is loaded before other toolkit related imports. This avoide errors like the sip api version #5.
