### PR TITLE
Import QApplication from the right place

### DIFF
--- a/traits_enaml/compat.py
+++ b/traits_enaml/compat.py
@@ -1,0 +1,22 @@
+#----------------------------------------------------------------------------
+#
+#  Copyright (c) 2018, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in /LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+#----------------------------------------------------------------------------
+""" Compatibility module to support a wider range of enaml versions.
+
+"""
+__all__ = ['QApplication']
+
+try:
+    from enaml.qt.QtGui import QApplication
+except ImportError:
+    from enaml.qt.QtWidgets import QApplication

--- a/traits_enaml/compat.py
+++ b/traits_enaml/compat.py
@@ -14,9 +14,14 @@
 """ Compatibility module to support a wider range of enaml versions.
 
 """
-__all__ = ['QApplication']
+__all__ = ['QApplication', 'QGLWidget']
 
 try:
     from enaml.qt.QtGui import QApplication
 except ImportError:
     from enaml.qt.QtWidgets import QApplication
+
+try:
+    from enaml.qt.QtOpenGL import QGLWidget
+except:
+    from qtpy.QtOpenGL import QGLWidget

--- a/traits_enaml/testing/event_loop_helper.py
+++ b/traits_enaml/testing/event_loop_helper.py
@@ -15,8 +15,10 @@ import contextlib
 import threading
 
 from enaml.application import deferred_call
-from enaml.qt import QtCore, QtWidgets
+from enaml.qt import QtCore
 from traits.api import HasStrictTraits, Instance
+
+from traits_enaml.compat import QApplication
 
 
 class ConditionTimeoutError(RuntimeError):
@@ -25,7 +27,7 @@ class ConditionTimeoutError(RuntimeError):
 
 class EventLoopHelper(HasStrictTraits):
 
-    qt_app = Instance(QtWidgets.QApplication)
+    qt_app = Instance(QApplication)
 
     def event_loop_with_timeout(self, repeat=2, timeout=10.0):
         """Helper function to send all posted events to the event queue and

--- a/traits_enaml/testing/event_loop_helper.py
+++ b/traits_enaml/testing/event_loop_helper.py
@@ -15,7 +15,7 @@ import contextlib
 import threading
 
 from enaml.application import deferred_call
-from enaml.qt import QtCore, QtGui
+from enaml.qt import QtCore, QtWidgets
 from traits.api import HasStrictTraits, Instance
 
 
@@ -25,7 +25,7 @@ class ConditionTimeoutError(RuntimeError):
 
 class EventLoopHelper(HasStrictTraits):
 
-    qt_app = Instance(QtGui.QApplication)
+    qt_app = Instance(QtWidgets.QApplication)
 
     def event_loop_with_timeout(self, repeat=2, timeout=10.0):
         """Helper function to send all posted events to the event queue and

--- a/traits_enaml/testing/gui_test_assistant.py
+++ b/traits_enaml/testing/gui_test_assistant.py
@@ -16,11 +16,11 @@ import threading
 
 from enaml.application import deferred_call
 from enaml.qt.qt_application import QtApplication
-from enaml.qt.QtWidgets import QApplication
 from traits.testing.unittest_tools import UnittestTools
 from traits.testing.unittest_tools import _TraitsChangeCollector as \
     TraitsChangeCollector
 
+from traits_enaml.compat import QApplication
 from .event_loop_helper import EventLoopHelper, ConditionTimeoutError
 
 

--- a/traits_enaml/testing/gui_test_assistant.py
+++ b/traits_enaml/testing/gui_test_assistant.py
@@ -16,7 +16,7 @@ import threading
 
 from enaml.application import deferred_call
 from enaml.qt.qt_application import QtApplication
-from enaml.qt.QtGui import QApplication
+from enaml.qt.QtWidgets import QApplication
 from traits.testing.unittest_tools import UnittestTools
 from traits.testing.unittest_tools import _TraitsChangeCollector as \
     TraitsChangeCollector

--- a/traits_enaml/testing/tests/test_gui_test_assistant.py
+++ b/traits_enaml/testing/tests/test_gui_test_assistant.py
@@ -104,7 +104,7 @@ class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
 
     def test_find_qt_widget(self):
         app = self.qt_app
-        self.assertIsNone(self.find_qt_widget(app, QtGui.QDockWidget))
+        self.assertIsNone(self.find_qt_widget(app, QtGui.QBitmap))
         self.assertIsInstance(
             self.find_qt_widget(app, QtGui.QSessionManager),
             QtGui.QSessionManager)

--- a/traits_enaml/widgets/gl_canvas.py
+++ b/traits_enaml/widgets/gl_canvas.py
@@ -20,7 +20,7 @@ if enaml_version < (0, 9, 6):
 from enaml.widgets.api import RawWidget
 from enaml.core.declarative import d_func
 
-from enaml.qt.QtOpenGL import QGLWidget
+from traits_enaml.compat import QGLWidget
 
 
 class _GLWidget(QGLWidget):


### PR DESCRIPTION
`enaml` is now using `qtpy`, which appears to force Qt5 import locations.

Seen from enthought/ensemble#59