### PR TITLE
Support cases where ETS_TOOLKIT=null.

### DIFF
--- a/traits_enaml/__init__.py
+++ b/traits_enaml/__init__.py
@@ -17,10 +17,11 @@ import enaml
 
 from .trait_operators import TRAIT_OPERATORS
 
-if ETSConfig.toolkit not in ['', 'qt4']:
+if ETSConfig.toolkit not in ['', 'qt4', 'null']:
     raise ValueError('traits-enaml does not support WX')
 
-ETSConfig.toolkit = 'qt4'
+if ETSConfig.toolkit != 'null':
+    ETSConfig.toolkit = 'qt4'
 
 
 def imports():


### PR DESCRIPTION
While this may not make sense for a UI-toolkit, this is handy when you
want to import code or run code that uses traits enaml remotely without
a screen.