### PR TITLE
Use xenial linux in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: generic
 dist: xenial
 services:
   - xvfb
+addons:
+  apt:
+    packages:
+      - libglu1-mesa
 env:
   global:
     - INSTALL_EDM_VERSION=1.9.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: generic
-sudo: false
+dist: xenial
+services:
+  - xvfb
 env:
   global:
     - INSTALL_EDM_VERSION=1.9.2
@@ -39,8 +41,6 @@ cache:
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - export PATH="/usr/lib/ccache/usr/local/bin:${HOME}/edm/bin:${PATH}"
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - ccache -s
 install:
   - ./install-edm-linux.sh


### PR DESCRIPTION
Travis is changing the default os to Xenial from Trusty linux. This change needs a change in how `xvfb` is started in the CI.

This PR also makes a driveby change by removing `sudo : false` from the travis config file which isn't needed anymore.